### PR TITLE
sbtの<++=のWarningを駆逐

### DIFF
--- a/project/StaticAnalysis.scala
+++ b/project/StaticAnalysis.scala
@@ -24,7 +24,7 @@ object StaticAnalysis {
         * 標準ではテストコードをチェックする場合 sbt test:scalastyle を叩くことになるが、
         * この設定を入れることで sbt scalastyle を叩いたときも、テストコードをチェックしてくれる。
         */
-      scalastyleSources in Compile <++= sourceDirectories in Test,
+      scalastyleSources in Compile ++= (sourceDirectories in Test).value,
 
       /**
         * テスト時に Scalastyle も一緒に実行するよう設定


### PR DESCRIPTION
下記Warningを駆逐

```
[warn] /root/repo/project/StaticAnalysis.scala:27: `<++=` operator is deprecated. Try `lhs ++= { x.value }`
[warn]   or see http://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html.
[warn]       scalastyleSources in Compile <++= sourceDirectories in Test,
```

* 参考
  * http://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html