### PR TITLE
依存ライブラリのバージョンアップ＆sbt-updatesの除外設定を追加

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,7 +25,7 @@ object Version {
   val DispatchCore = "0.13.1"
 
   // ロギング関連
-  val LogstashLogbackEncoder = "4.9"
+  val LogstashLogbackEncoder = "4.11"
   val Janino = "3.0.7"
 
   // テスト関連

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,7 +30,7 @@ object Version {
 
   // テスト関連
   val MockitoCore = "2.8.47"
-  val ScalatestplusPlay = "3.0.0"
+  val ScalatestplusPlay = "3.1.0"
 }
 
 // noinspection TypeAnnotation

--- a/project/StaticAnalysis.scala
+++ b/project/StaticAnalysis.scala
@@ -8,10 +8,11 @@ import play.sbt.routes.RoutesKeys.routes
 import sbt.Keys._
 import sbt._
 import wartremover.WartRemover.autoImport._
+import com.timushev.sbt.updates.UpdatesKeys._
 
 // noinspection TypeAnnotation
 object StaticAnalysis {
-  val Settings = WartRemover.Settings ++ Scalastyle.Settings ++ CPD.Settings
+  val Settings = WartRemover.Settings ++ Scalastyle.Settings ++ CPD.Settings ++ Updates.Settings
   val PlaySettings = WartRemover.PlaySettings
 
   object Scalastyle {
@@ -111,6 +112,19 @@ object StaticAnalysis {
         * @see https://github.com/sbt/cpd4sbt/blob/master/src/main/scala/de/johoop/cpd4sbt/Settings.scala#L33
         */
       cpdMinimumTokens := 30
+    )
+  }
+
+  object Updates {
+
+    val Settings = Seq(
+      /**
+        * sbt-updates の依存ライブラリアップデートチェックの対象外を設定
+        *
+        * dependencyUpdatesExclusions は非推奨になったから代わりに
+        * dependencyUpdatesFilter を使えって書いてあるけど、なぜか使えない。。
+        */
+      dependencyUpdatesExclusions := moduleFilter(organization = "net.sourceforge.pmd") // cpd はライブラリが更新されてないので除外
     )
   }
 


### PR DESCRIPTION
Before

```
[info] Found 4 dependency updates for play-starter
[info]   mysql:mysql-connector-java                     : 5.1.42                   -> 8.0.7
[info]   net.logstash.logback:logstash-logback-encoder  : 4.9             -> 4.11
[info]   net.sourceforge.pmd:pmd-dist:cpd->default      : 5.4.2  -> 5.4.6 -> 5.8.1
[info]   org.scalatestplus.play:scalatestplus-play:test : 3.0.0           -> 3.1.0
```

After

```
[info] Found 1 dependency update for play-starter
[info]   mysql:mysql-connector-java : 5.1.42 -> 8.0.7
```

ちなみに、除外設定の書き方がアレなせいで、警告が出るが諦めた。

```
[warn] /Users/owner/github/play-starter/project/StaticAnalysis.scala:127: value dependencyUpdatesExclusions in trait UpdatesKeys is deprecated: dependencyUpdatesExclusions is deprecated in favor of dependencyUpdatesFilter, which defaults to a truthy check. Migrate exclusions by setting dependencyUpdatesFilter -= yourExclusions
[warn]       dependencyUpdatesExclusions := moduleFilter(organization = "net.sourceforge.pmd") // cpd はライブラリが更新されてないので除外
[warn]       ^
[warn] one warning found
```