### PR TITLE
Scalaを2.12.3にバージョンアップ

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -11,7 +11,7 @@ object BuildSettings {
     /**
       * Scalaのバージョン
       */
-    scalaVersion := "2.12.2",
+    scalaVersion := "2.12.3",
 
     /**
       * システムのタイムゾーンを指定


### PR DESCRIPTION
## Before

```
$ dependencyUpdates
[info] Found 15 dependency updates for play-starter
[info]   com.typesafe.play:filters-helpers                    : 2.6.2  -> 2.6.5
[info]   com.typesafe.play:play-akka-http-server              : 2.6.2  -> 2.6.5
[info]   com.typesafe.play:play-guice                         : 2.6.2  -> 2.6.5
[info]   com.typesafe.play:play-jdbc                          : 2.6.2  -> 2.6.5
[info]   com.typesafe.play:play-logback                       : 2.6.2  -> 2.6.5
[info]   com.typesafe.play:play-omnidoc:docs                  : 2.6.2  -> 2.6.5
[info]   com.typesafe.play:play-server                        : 2.6.2  -> 2.6.5
[info]   com.typesafe.play:play-test:test                     : 2.6.2  -> 2.6.5
[info]   com.typesafe.play:twirl-api                          : 1.3.3  -> 1.3.7
[info]   mysql:mysql-connector-java                           : 5.1.43 -> 5.1.44           -> 8.0.7
[info]   org.mockito:mockito-core:test                        : 2.8.47           -> 2.10.0
[info]   org.scala-lang:scala-library                         : 2.12.2 -> 2.12.3
[info]   org.scalatestplus.play:scalatestplus-play:test       : 3.1.1  -> 3.1.2
[info]   org.skinny-framework:skinny-orm                      : 2.3.7  -> 2.3.9  -> 2.4.0
[info]   org.wartremover:wartremover:plugin->default(compile) : 2.1.1            -> 2.2.0
```

## After

```
$ dependencyUpdates
[info] Found 14 dependency updates for play-starter
[info]   com.typesafe.play:filters-helpers                    : 2.6.2  -> 2.6.5
[info]   com.typesafe.play:play-akka-http-server              : 2.6.2  -> 2.6.5
[info]   com.typesafe.play:play-guice                         : 2.6.2  -> 2.6.5
[info]   com.typesafe.play:play-jdbc                          : 2.6.2  -> 2.6.5
[info]   com.typesafe.play:play-logback                       : 2.6.2  -> 2.6.5
[info]   com.typesafe.play:play-omnidoc:docs                  : 2.6.2  -> 2.6.5
[info]   com.typesafe.play:play-server                        : 2.6.2  -> 2.6.5
[info]   com.typesafe.play:play-test:test                     : 2.6.2  -> 2.6.5
[info]   com.typesafe.play:twirl-api                          : 1.3.3  -> 1.3.7
[info]   mysql:mysql-connector-java                           : 5.1.43 -> 5.1.44           -> 8.0.7
[info]   org.mockito:mockito-core:test                        : 2.8.47           -> 2.10.0
[info]   org.scalatestplus.play:scalatestplus-play:test       : 3.1.1  -> 3.1.2
[info]   org.skinny-framework:skinny-orm                      : 2.3.7  -> 2.3.9  -> 2.4.0
[info]   org.wartremover:wartremover:plugin->default(compile) : 2.1.1            -> 2.2.0
```