### PR TITLE
Playを2.6.5にバージョンアップ

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,7 +33,7 @@ object Version {
   val ScalatestplusPlay = "3.1.1"
 
   // 共通ライブラリ関連
-  val PlayFramework = "2.6.2" // plugins.sbt の定義と合わせること
+  val PlayFramework = "2.6.5" // plugins.sbt の定義と合わせること
   val FlywayCore = "4.2.0"
 }
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.2")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.5")
 
 /**
   * マイグレーションツール


### PR DESCRIPTION
## Before

```
$ dependencyUpdates
[info] Found 14 dependency updates for play-starter
[info]   com.typesafe.play:filters-helpers                    : 2.6.2  -> 2.6.5
[info]   com.typesafe.play:play-akka-http-server              : 2.6.2  -> 2.6.5
[info]   com.typesafe.play:play-guice                         : 2.6.2  -> 2.6.5
[info]   com.typesafe.play:play-jdbc                          : 2.6.2  -> 2.6.5
[info]   com.typesafe.play:play-logback                       : 2.6.2  -> 2.6.5
[info]   com.typesafe.play:play-omnidoc:docs                  : 2.6.2  -> 2.6.5
[info]   com.typesafe.play:play-server                        : 2.6.2  -> 2.6.5
[info]   com.typesafe.play:play-test:test                     : 2.6.2  -> 2.6.5
[info]   com.typesafe.play:twirl-api                          : 1.3.3  -> 1.3.7
[info]   mysql:mysql-connector-java                           : 5.1.43 -> 5.1.44           -> 8.0.7
[info]   org.mockito:mockito-core:test                        : 2.8.47           -> 2.10.0
[info]   org.scalatestplus.play:scalatestplus-play:test       : 3.1.1  -> 3.1.2
[info]   org.skinny-framework:skinny-orm                      : 2.3.7  -> 2.3.9  -> 2.4.0
[info]   org.wartremover:wartremover:plugin->default(compile) : 2.1.1            -> 2.2.0
```

## After

```
$ dependencyUpdates
[info] Found 6 dependency updates for play-starter
[info]   com.typesafe.play:twirl-api                          : 1.3.4  -> 1.3.7
[info]   mysql:mysql-connector-java                           : 5.1.43 -> 5.1.44           -> 8.0.7
[info]   org.mockito:mockito-core:test                        : 2.8.47           -> 2.10.0
[info]   org.scalatestplus.play:scalatestplus-play:test       : 3.1.1  -> 3.1.2
[info]   org.skinny-framework:skinny-orm                      : 2.3.7  -> 2.3.9  -> 2.4.0
[info]   org.wartremover:wartremover:plugin->default(compile) : 2.1.1            -> 2.2.0
```