### PR TITLE
依存ライブラリをバージョンアップ

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ import sbt._
 
 object Version {
   // DB関連
-  val MysqlConnectorJava = "5.1.43"
+  val MysqlConnectorJava = "5.1.44"
   val SkinnyOrm = "2.3.7"
   val ScalikejdbcPlayInitializer = "2.6.0"
   val ScalikejdbcJsr310 = "2.5.2"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -29,7 +29,7 @@ object Version {
   val Janino = "3.0.7"
 
   // テスト関連
-  val MockitoCore = "2.8.47"
+  val MockitoCore = "2.10.0"
   val ScalatestplusPlay = "3.1.2"
 
   // 共通ライブラリ関連

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,7 @@ import sbt._
 object Version {
   // DB関連
   val MysqlConnectorJava = "5.1.44"
-  val SkinnyOrm = "2.3.7"
+  val SkinnyOrm = "2.4.0"
   val ScalikejdbcPlayInitializer = "2.6.0"
   val ScalikejdbcJsr310 = "2.5.2"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,7 +30,7 @@ object Version {
 
   // テスト関連
   val MockitoCore = "2.8.47"
-  val ScalatestplusPlay = "3.1.1"
+  val ScalatestplusPlay = "3.1.2"
 
   // 共通ライブラリ関連
   val PlayFramework = "2.6.5" // plugins.sbt の定義と合わせること


### PR DESCRIPTION
## Before

```
$ dependencyUpdates
[info] Found 6 dependency updates for play-starter
[info]   com.typesafe.play:twirl-api                          : 1.3.4  -> 1.3.7
[info]   mysql:mysql-connector-java                           : 5.1.43 -> 5.1.44           -> 8.0.7
[info]   org.mockito:mockito-core:test                        : 2.8.47           -> 2.10.0
[info]   org.scalatestplus.play:scalatestplus-play:test       : 3.1.1  -> 3.1.2
[info]   org.skinny-framework:skinny-orm                      : 2.3.7  -> 2.3.9  -> 2.4.0
[info]   org.wartremover:wartremover:plugin->default(compile) : 2.1.1            -> 2.2.0
```

## After

```
$ dependencyUpdates
[info] Found 3 dependency updates for play-starter
[info]   com.typesafe.play:twirl-api                          : 1.3.4  -> 1.3.7
[info]   mysql:mysql-connector-java                           : 5.1.44                   -> 8.0.7
[info]   org.wartremover:wartremover:plugin->default(compile) : 2.1.1           -> 2.2.0
```