### PR TITLE
discarded non-Unit value警告を抑制

### DIFF
--- a/library/test/src/main/scala/library/test/DatabaseSpec.scala
+++ b/library/test/src/main/scala/library/test/DatabaseSpec.scala
@@ -9,7 +9,7 @@ trait DatabaseSpec extends PlaySpec with GuiceOneAppPerSuite with BeforeAndAfter
   private lazy val flyway = Flyway(app.injector)
 
   override def beforeEach(): Unit = {
-    flyway.migrate()
+    val _ = flyway.migrate()
   }
 
   override def afterEach(): Unit = {


### PR DESCRIPTION
こんなん出てた。

```
[warn] /Users/owner/github/play-starter/library/test/src/main/scala/library/test/DatabaseSpec.scala:12: discarded non-Unit value
[warn]     flyway.migrate()
[warn]                   ^
[warn] one warning found
```