### PR TITLE
依存ライブラリをバージョンアップ

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -29,7 +29,7 @@ object Version {
   val Janino = "3.0.7"
 
   // テスト関連
-  val MockitoCore = "2.10.0"
+  val MockitoCore = "2.12.0"
   val ScalatestplusPlay = "3.1.2"
 
   // 共通ライブラリ関連

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Version {
   val ScalikejdbcJsr310 = "2.5.2"
 
   // JSON関連
-  val SprayJson = "1.3.3"
+  val SprayJson = "1.3.4"
 
   // 通信関連
   val DispatchCore = "0.13.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,7 +22,7 @@ object Version {
   val SprayJson = "1.3.4"
 
   // 通信関連
-  val DispatchCore = "0.13.1"
+  val DispatchCore = "0.13.2"
 
   // ロギング関連
   val LogstashLogbackEncoder = "4.11"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.5")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.7")
 
 /**
   * マイグレーションツール

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -50,7 +50,7 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
   *
   * @see http://www.wartremover.org/
   */
-addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.1.1")
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.2.1")
 
 /**
   * コピペチェック


### PR DESCRIPTION
削除予定のモノはそのまま。

## Before

```
$ dependencyUpdates
[info] Found 16 dependency updates for play-starter
[info]   com.typesafe.play:filters-helpers                    : 2.6.5  -> 2.6.7
[info]   com.typesafe.play:play-akka-http-server              : 2.6.5  -> 2.6.7
[info]   com.typesafe.play:play-guice                         : 2.6.5  -> 2.6.7
[info]   com.typesafe.play:play-jdbc                          : 2.6.5  -> 2.6.7
[info]   com.typesafe.play:play-logback                       : 2.6.5  -> 2.6.7
[info]   com.typesafe.play:play-omnidoc:docs                  : 2.6.5  -> 2.6.7
[info]   com.typesafe.play:play-server                        : 2.6.5  -> 2.6.7
[info]   com.typesafe.play:play-test:test                     : 2.6.5  -> 2.6.7
[info]   com.typesafe.play:twirl-api                          : 1.3.4  -> 1.3.13
[info]   io.spray:spray-json                                  : 1.3.3  -> 1.3.4
[info]   mysql:mysql-connector-java                           : 5.1.44                     -> 8.0.8
[info]   net.databinder.dispatch:dispatch-core                : 0.13.1 -> 0.13.2
[info]   org.mockito:mockito-core:test                        : 2.10.0           -> 2.12.0
[info]   org.skinny-framework:skinny-orm                      : 2.4.0            -> 2.5.2
[info]   org.wartremover:wartremover:plugin->default(compile) : 2.1.1            -> 2.2.1
```

## After

```
$ dependencyUpdates
[info] Found 3 dependency updates for play-starter
[info]   com.typesafe.play:twirl-api     : 1.3.12 -> 1.3.13
[info]   mysql:mysql-connector-java      : 5.1.44                    -> 8.0.8
[info]   org.skinny-framework:skinny-orm : 2.4.0            -> 2.5.2
```