### PR TITLE
 twirl-apiとmysql-connector-javaをsbt-updatesのチェック対象外に設定

### DIFF
--- a/project/StaticAnalysis.scala
+++ b/project/StaticAnalysis.scala
@@ -122,8 +122,16 @@ object StaticAnalysis {
         *
         * dependencyUpdatesExclusions は非推奨になったから代わりに
         * dependencyUpdatesFilter を使えって書いてあるけど、なぜか使えない。。
+        *
+        * - twirl-api
+        *   - Scala ベースのテンプレートエンジンで、そもそも不要だが Play では標準で組み込まれてしまう
+        *   - だが Play とライフサイクルが異なるらしく Play を最新にしても、アップデートを促されるケースが多い
+        *   - 使いもしない twirl-api を最新にしておく必要はなく、ノイズにもなるので、チェック対象から除外する
+        * - net.sourceforge.pmd
+        *   - cpd はライブラリが更新されてないので除外
         */
-      dependencyUpdatesExclusions := moduleFilter(organization = "net.sourceforge.pmd") // cpd はライブラリが更新されてないので除外
+      dependencyUpdatesExclusions := moduleFilter(organization = "net.sourceforge.pmd")
+        | moduleFilter(name = "twirl-api")
     )
   }
 

--- a/project/StaticAnalysis.scala
+++ b/project/StaticAnalysis.scala
@@ -123,15 +123,19 @@ object StaticAnalysis {
         * dependencyUpdatesExclusions は非推奨になったから代わりに
         * dependencyUpdatesFilter を使えって書いてあるけど、なぜか使えない。。
         *
+        * - net.sourceforge.pmd
+        *   - cpd はライブラリが更新されてないので除外
         * - twirl-api
         *   - Scala ベースのテンプレートエンジンで、そもそも不要だが Play では標準で組み込まれてしまう
         *   - だが Play とライフサイクルが異なるらしく Play を最新にしても、アップデートを促されるケースが多い
         *   - 使いもしない twirl-api を最新にしておく必要はなく、ノイズにもなるので、チェック対象から除外する
-        * - net.sourceforge.pmd
-        *   - cpd はライブラリが更新されてないので除外
+        * - mysql-connector-java
+        *   - なぜか 8.X 系にアップデートを促される
+        *   - 少なくとも Play では 5.X 系を使うのが正しそうなので、チェック対象外にしてしまう
         */
       dependencyUpdatesExclusions := moduleFilter(organization = "net.sourceforge.pmd")
         | moduleFilter(name = "twirl-api")
+        | moduleFilter(name = "mysql-connector-java")
     )
   }
 


### PR DESCRIPTION
## Before

```
$ dependencyUpdates
[info] Found 3 dependency updates for play-starter
[info]   com.typesafe.play:twirl-api     : 1.3.12 -> 1.3.13
[info]   mysql:mysql-connector-java      : 5.1.44                    -> 8.0.8
[info]   org.skinny-framework:skinny-orm : 2.4.0            -> 2.5.2
```

## After

```
$ dependencyUpdates
[info] Found 1 dependency update for play-starter
[info]   org.skinny-framework:skinny-orm : 2.4.0 -> 2.5.2
```